### PR TITLE
#32360 Adding comma separator to the DOT_REMOTE_CALL_SUBNET_BLACKLIST default value.

### DIFF
--- a/charts/dotcms/Chart.yaml
+++ b/charts/dotcms/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dotcms
 description: A Helm chart for DotCMS cluster
 type: application
-version: 1.0.23
+version: 1.0.24
 appVersion: 1.0.0
 maintainers:
   - name: dcolina

--- a/charts/dotcms/values.yaml
+++ b/charts/dotcms/values.yaml
@@ -303,7 +303,7 @@ envVarsDefaults:
   # @default -- 0.0.0.0/0
   DOT_SYSTEM_STATUS_API_IP_ACL: "0.0.0.0/0"
   # -- List of IPs/subnets to block from making remote calls
-  DOT_REMOTE_CALL_SUBNET_BLACKLIST: "169.254.169.254/32127.0.0.1/3210.0.0.0/8172.16.0.0/12192.168.0.0/16"
+  DOT_REMOTE_CALL_SUBNET_BLACKLIST: "169.254.169.254/32,127.0.0.1/32,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
   # -- Whether remote calls should follow redirects
   # @default -- "true"
   DOT_REMOTE_CALL_ALLOW_REDIRECTS: "true"


### PR DESCRIPTION
## Proposed Changes

This pull request includes a small but important change to the `DOT_REMOTE_CALL_SUBNET_BLACKLIST` configuration in the `charts/dotcms/values.yaml` file. The change corrects the formatting of the subnet list by adding commas to separate entries, ensuring proper parsing and functionality.

