### PR TITLE
feat(helm): Add podManagementPolicy and PodDisruptionBudget co (#58)

### DIFF
--- a/charts/dotcms/Chart.yaml
+++ b/charts/dotcms/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dotcms
 description: A Helm chart for DotCMS cluster
 type: application
-version: 1.0.24
+version: 1.0.25
 appVersion: 1.0.0
 maintainers:
   - name: dcolina

--- a/charts/dotcms/templates/pdb.yaml
+++ b/charts/dotcms/templates/pdb.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.coreServiceEnabled }}
+{{- range $envName := keys $.Values.environments }}
+{{- with include "myapp.mergeEnvironment" ( mergeOverwrite $ (dict "envName" $envName )) | fromYaml }}
+{{- $fullName := include "dotcms.env.fullName" . }}
+{{- if or (eq (toString .Values.pdb.enabled) "true") (and (eq (toString .Values.pdb.enabled) "auto") (gt (int .Values.replicas) 1)) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  namespace: {{ include "dotcms.name.customer" . }}
+  name: {{ $fullName }}-pdb
+  labels:
+    {{- if eq $.Values.cloudProvider "aws" }}
+    app.dotcms.cloud/aws-region: {{ $.Values.aws.region }}
+    {{- end }}
+    app.kubernetes.io/instance: {{ $.Values.customerName }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      fullname: {{ $fullName }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/dotcms/templates/statefulset.yaml
+++ b/charts/dotcms/templates/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
       fullname: {{ $fullName }}
   serviceName: {{ $fullName }}
   replicas: {{ .Values.replicas }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   template:
     metadata:
       annotations:

--- a/charts/dotcms/values.yaml
+++ b/charts/dotcms/values.yaml
@@ -39,6 +39,18 @@ configVersion: 1
 # -- Number of replicas to deploy
 # @default -- 1
 replicas: 1
+# -- Pod management policy for the StatefulSet (OrderedReady, Parallel)
+# @default -- OrderedReady
+podManagementPolicy: OrderedReady
+
+# PodDisruptionBudget configuration
+pdb:
+  # -- Enable PodDisruptionBudget (auto: enabled when replicas > 1, true: always enabled, false: disabled)
+  # @default -- auto
+  enabled: auto
+  # -- Minimum number of pods that must be available during disruptions
+  # @default -- 1
+  minAvailable: 1
 # Resource limits and requests for the main container
 resources:
   requests:


### PR DESCRIPTION
## Description

Add configurable podManagementPolicy and PodDisruptionBudget support to improve StatefulSet management and high availability.

## Changes
- Added podManagementPolicy configuration option to values.yaml (defaults to OrderedReady)
- Updated StatefulSet template to support podManagementPolicy
- Created new pdb.yaml template with conditional PodDisruptionBudget creation
- Implemented three PDB modes: auto (default), true, false
- Auto mode only creates PDB when replicas > 1
- Added configurable minAvailable parameter (defaults to 1)

## Testing
- Validated template rendering with different replica counts
- Verified PDB creation logic for all three modes (auto/true/false)
- Tested podManagementPolicy configuration options
- Confirmed backward compatibility with existing deployments

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #58

**Issue:** Add podManagementPolicy and PodDisruptionBudget co