### PR TITLE
fix(helm): Fix inconsistent management endpoint paths from do (#68)

### DIFF
--- a/charts/dotcms/Chart.yaml
+++ b/charts/dotcms/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dotcms
 description: A Helm chart for DotCMS cluster
 type: application
-version: 1.0.31
+version: 1.0.32
 appVersion: 1.0.0
 maintainers:
   - name: dcolina

--- a/charts/dotcms/values.yaml
+++ b/charts/dotcms/values.yaml
@@ -486,8 +486,8 @@ backup:
 startupProbe:
   httpGet:
     # -- Path to check for readiness
-    # @default -- /dotmgmt/readyz
-    path: /dotmgmt/readyz
+    # @default -- /dotmgt/readyz
+    path: /dotmgt/readyz
     # -- Port used for the readiness probe (defaults to management port if enabled)
     # @default -- 8090
     port: 8090
@@ -511,8 +511,8 @@ startupProbe:
 livenessProbe:
   httpGet:
     # -- Path to check liveness
-    # @default -- /dotmgmt/livez
-    path: /dotmgmt/livez
+    # @default -- /dotmgt/livez
+    path: /dotmgt/livez
     # -- Port used for the liveness probe
     # @default -- 8090
     port: 8090
@@ -536,8 +536,8 @@ livenessProbe:
 readinessProbe:
   httpGet:
     # -- Path to check readiness
-    # @default -- /dotmgmt/readyz
-    path: /dotmgmt/readyz
+    # @default -- /dotmgt/readyz
+    path: /dotmgt/readyz
     # -- Port used for the readiness probe
     # @default -- 8090
     port: 8090


### PR DESCRIPTION
## Description

Standardize management endpoint paths to use consistent /dotmgt prefix across all probe configurations. This fixes inconsistent endpoint naming that was using both /dotmgmt and /dotmgt prefixes throughout the chart.

**Key Changes:**
- Fix startup probe path: /dotmgmt/readyz → /dotmgt/readyz
- Fix liveness probe path: /dotmgmt/livez → /dotmgt/livez  
- Fix readiness probe path: /dotmgmt/readyz → /dotmgt/readyz
- Update corresponding documentation and default comments
- Prometheus metrics path already correct at /dotmgt/metrics

**Testing:**
- Validated template parsing with corrected endpoint paths
- Confirmed all probe configurations use consistent /dotmgt prefix
- Verified ALB health checks point to correct management endpoints

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #68

**Issue:** Fix inconsistent management endpoint paths from do