### PR TITLE
feat(helm): Enhancement Add support for multiple monitoring na (#72)

### DIFF
--- a/charts/dotcms/Chart.yaml
+++ b/charts/dotcms/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dotcms
 description: A Helm chart for DotCMS cluster
 type: application
-version: 1.0.33
+version: 1.0.34
 appVersion: 1.0.0
 maintainers:
   - name: dcolina

--- a/charts/dotcms/templates/allow-prometheus-monitoring.yaml
+++ b/charts/dotcms/templates/allow-prometheus-monitoring.yaml
@@ -13,15 +13,17 @@ spec:
   - Ingress
   ingress:
   - from:
+    {{- range .Values.networkPolicy.allowPrometheusMonitoring.namespaceSelectors }}
     - namespaceSelector:
         matchLabels:
-          {{- range $key, $value := .Values.networkPolicy.allowPrometheusMonitoring.namespaceSelector }}
+          {{- range $key, $value := . }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
-    {{- if .Values.networkPolicy.allowPrometheusMonitoring.podSelector }}
+    {{- end }}
+    {{- range .Values.networkPolicy.allowPrometheusMonitoring.podSelectors }}
     - podSelector:
         matchLabels:
-          {{- range $key, $value := .Values.networkPolicy.allowPrometheusMonitoring.podSelector }}
+          {{- range $key, $value := . }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
     {{- end }}

--- a/charts/dotcms/values.yaml
+++ b/charts/dotcms/values.yaml
@@ -676,11 +676,11 @@ networkPolicy:
     # -- Enable NetworkPolicy for Prometheus monitoring access
     # @default -- false
     enabled: false
-    # -- Namespace selector for Prometheus pods
-    # @default -- {"kubernetes.io/metadata.name": "monitoring"}
-    namespaceSelector:
-      kubernetes.io/metadata.name: monitoring
-    # -- Pod selector for Prometheus pods (optional)
-    # @default -- {"app.kubernetes.io/name": "prometheus"}
-    podSelector:
-      app.kubernetes.io/name: prometheus
+    # -- Namespace selectors for monitoring pods (supports multiple namespaces)
+    # @default -- [{"kubernetes.io/metadata.name": "monitoring"}]
+    namespaceSelectors:
+      - kubernetes.io/metadata.name: monitoring
+    # -- Pod selectors for monitoring pods (supports multiple selectors)
+    # @default -- [{"app.kubernetes.io/name": "prometheus"}]
+    podSelectors:
+      - app.kubernetes.io/name: prometheus


### PR DESCRIPTION
## Description

Add support for multiple monitoring namespaces and pod selectors in NetworkPolicy template. Updated values.yaml configuration structure to use arrays (namespaceSelectors, podSelectors) instead of single objects. Modified template to iterate through multiple selectors, enabling monitoring tools like Prometheus and Alloy across different namespaces (monitoring, observability).

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #72

**Issue:** Enhancement Add support for multiple monitoring na